### PR TITLE
atsea-test-for-coveralls to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -2,6 +2,9 @@ dependencies:
 - name: atsea-shop-app
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.96
+- name: atsea-test-for-coveralls
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote atsea-test-for-coveralls to version 0.0.1